### PR TITLE
3個のバグを修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -19,7 +19,8 @@ def take_order(menus)
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  # 添え字を0始まりに合わせる。
+  order_number = gets.to_i - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end
@@ -30,5 +31,5 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = DRINKS[order1][:price].to_i + FOODS[order2][:price].to_i
 puts "お会計は#{total}円になります。ありがとうございました！"


### PR DESCRIPTION
1. 頼んだつもりのメニューが選択できない。
2. 最後の番号のメニューを選択するとエラーとなる。
⇒原因：23行目で配列の添え字が0で始まるのに、入力された数字をそのまま入れていた。

3.お会計額が異様に高い。
⇒原因：34行目で数字の足し算でなく、文字列の足し算が行われていた。

4.違う番号のドリンク、フードを注文したとき、お会計が正しくない。
⇒原因：34行目でorder1でFOODSから、order2でDRINKSから、金額を取得している。
order1はドリンクの選択したものの番号、order2はフードの選択したものの番号であるから問題である。